### PR TITLE
Add independent interest level filters to each status column

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -16,6 +16,9 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Badge } from "@/components/ui/badge";
 
+type InterestFilter = "All" | "High" | "Medium" | "Low";
+const INTEREST_FILTERS: InterestFilter[] = ["All", "High", "Medium", "Low"];
+
 const columnColors: Record<string, string> = {
   Bookmarked: "bg-blue-500",
   Applied: "bg-indigo-500",
@@ -35,10 +38,18 @@ function KanbanColumn({
   prospects: Prospect[];
   isLoading: boolean;
 }) {
+  const [interestFilter, setInterestFilter] = useState<InterestFilter>("All");
+  const slugStatus = status.replace(/\s+/g, "-").toLowerCase();
+
+  const filteredProspects =
+    interestFilter === "All"
+      ? prospects
+      : prospects.filter((p) => p.interestLevel === interestFilter);
+
   return (
     <div
       className="flex flex-col min-w-[260px] max-w-[320px] w-full bg-muted/40 rounded-md"
-      data-testid={`column-${status.replace(/\s+/g, "-").toLowerCase()}`}
+      data-testid={`column-${slugStatus}`}
     >
       <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/50">
         <div className={`w-2 h-2 rounded-full ${columnColors[status] || "bg-gray-400"}`} />
@@ -46,24 +57,44 @@ function KanbanColumn({
         <Badge
           variant="secondary"
           className="ml-auto text-[10px] px-1.5 py-0 h-5 min-w-[20px] flex items-center justify-center no-default-active-elevate"
-          data-testid={`badge-count-${status.replace(/\s+/g, "-").toLowerCase()}`}
+          data-testid={`badge-count-${slugStatus}`}
         >
-          {prospects.length}
+          {filteredProspects.length}
         </Badge>
       </div>
-      <div className="flex-1 overflow-y-auto px-2 py-2">
+
+      <div className="flex items-center gap-1 px-2 pt-2 pb-1 flex-wrap">
+        {INTEREST_FILTERS.map((level) => (
+          <button
+            key={level}
+            onClick={() => setInterestFilter(level)}
+            data-testid={`filter-${slugStatus}-${level.toLowerCase()}`}
+            className={`text-[10px] px-2 py-0.5 rounded-full border font-medium transition-colors ${
+              interestFilter === level
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-transparent text-muted-foreground border-border hover:border-foreground/40 hover:text-foreground"
+            }`}
+          >
+            {level}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-2 py-1">
         <div className="space-y-2">
           {isLoading ? (
             <>
               <Skeleton className="h-28 rounded-md" />
               <Skeleton className="h-20 rounded-md" />
             </>
-          ) : prospects.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${status.replace(/\s+/g, "-").toLowerCase()}`}>
-              <p className="text-xs text-muted-foreground">No prospects</p>
+          ) : filteredProspects.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-center" data-testid={`empty-${slugStatus}`}>
+              <p className="text-xs text-muted-foreground">
+                {prospects.length === 0 ? "No prospects" : "No matches"}
+              </p>
             </div>
           ) : (
-            prospects.map((prospect) => (
+            filteredProspects.map((prospect) => (
               <ProspectCard key={prospect.id} prospect={prospect} />
             ))
           )}


### PR DESCRIPTION
Adds client-side interest level filtering (All, High, Medium, Low) to each Kanban column, updating badge counts and card visibility without server interaction.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: b58ffc24-587d-4b99-ae4c-eb19cee9a937
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: 60fd3ca8-405f-443d-bb3d-46e031e95348
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/5a947572-99af-473c-bb12-f949b7d8211b/b58ffc24-587d-4b99-ae4c-eb19cee9a937/N7wx9Fa
Replit-Helium-Checkpoint-Created: true